### PR TITLE
docfix

### DIFF
--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -3,7 +3,7 @@
 #' The `IdVector` class extends the [`Vector`][Vector-class] class to implement a container that hold a vector of character identifiers.
 #' Subclasses of `IdVector` may be defined to enable method dispatch according to the nature of the identifiers (e.g., ENTREZ gene, Gene Ontology term).
 #'
-#' @slot ids character. Unique identifiers.
+#' @slot ids character. Identifiers.
 #'
 #' @export
 #' @exportClass IdVector
@@ -71,9 +71,13 @@ IdVector <- function(ids=character(0)) {
 #'
 #' The `BaseSets` class implements a container to describe distinct objects that make up sets, along with element metadata and set metadata.
 #'
-#' @slot relations DataFrame. Two columns provide mapping relationships between `"element"` and `"set"`.
-#' @slot elementData DataFrame. Provide metadata for each unique element in `relations$element`.
-#' @slot setData DataFrame. Provide metadata for each unique element in `relations$set`.
+#' @slot relations [`Hits-class`]
+#' The _left node_ and _right node_ of each hit stores the index of the `element` and `set` in `elementData` and `setData`, respectively.
+#' Metadata for each relation is stored as `mcols(object@relations)`.
+#' @slot elementData [`IdVector`].
+#' Metadata for each unique element in `relations$element` is stored as `mcols(elementData)`.
+#' @slot setData [`IdVector`].
+#' Metadata for each unique set in `relations$set` is stored as `mcols(setData)`.
 #'
 #' @export
 #' @exportClass BaseSets
@@ -139,9 +143,13 @@ setClass("BaseSets",
 #' @rdname BaseSets-class
 #' @aliases BaseSets
 #'
-#' @param relations DataFrame. Two columns provide mapping relationships between `"element"` and `"set"`.
-#' @param elementData DataFrame. Provide metadata for each unique element in `relations$element`.
-#' @param setData DataFrame. Provide metadata for each unique element in `relations$set`.
+#' @param relations [`DataFrame-class`].
+#' At least two columns that provide mapping relationships between `"element"` and `"set"`.
+#' Additional columns are taken as relation metadata.
+#' @param elementData [`IdVector`].
+#' Metadata for each unique element in `relations$element` is provided as `mcols(elementData)`.
+#' @param setData [`IdVector`].
+#' Metadata for each unique set in `relations$set` is provided as `mcols(setData)`.
 #'
 #' @return A `BaseSets` object.
 #'
@@ -272,7 +280,7 @@ FuzzyHits <- function(
 
 #' FuzzySets Class
 #'
-#' The `FuzzySets` class extends the [`BaseSets`] class to implement a container that also describe different grades of membershipin the interval `[0,1]`.
+#' The `FuzzySets` class extends the [`BaseSets`] class to implement a container that also describe different grades of membership in the interval `[0,1]`.
 #'
 #' This class does not define any additional slot to the `BaseSets` class.
 #' However, this class defines additional validity checks to ensure that every relation stored in a `FuzzySets` are associated with a numeric membership funtion in the interval `[0,1]`.
@@ -340,7 +348,9 @@ setClass("FuzzySets",
 #' @rdname FuzzySets-class
 #' @aliases FuzzySets
 #'
-#' @param relations DataFrame. At least 3 columns provide mapping relationships between `"element"` and `"set"` with `"membership"` function in the range `[0,1]`.
+#' @param relations [`DataFrame-class`].
+#' At least 3 columns that provide mapping relationships between `"element"` and `"set"`, with `"membership"` function in the range `[0,1]`.
+#' Additional columns are taken as relation metadata.
 #' @param ... Arguments passed to the [`BaseSets()`] constructor and other functions.
 #'
 #' @return A `FuzzySets` object.

--- a/R/AllMethods.R
+++ b/R/AllMethods.R
@@ -4,7 +4,7 @@
 #' Methods for `BaseSets` Objects
 #'
 #' This page documents the S4 generics and methods defined for objects inheriting of the [`BaseSets`][BaseSets-class] class.
-#' In the usage below, `x` represents an object of class inheriting from [`BaseSets`][BaseSets-class],
+#' In the usage below, `object` and `x` represent an object of class inheriting from [`BaseSets`][BaseSets-class],
 #' and `value` is an object of a class specified in the S4 method signature or as outlined in 'Accessors'.
 #'
 #' @name BaseSets-methods
@@ -22,7 +22,7 @@ NULL
 #'
 #' This page documents the S4 generics and methods defined for objects inheriting of the [`FuzzyHits`][FuzzyHits-class] class.
 #' The `FuzzyHits` class directly extends [`Hits`][`Hits-class`] and thus inherits of all methods defined for the parent class.
-#' In the usage below, `x` represents an object of class inheriting from [`FuzzyHits`][FuzzyHits-class],
+#' In the usage below, `object` represents an object of class inheriting from [`FuzzyHits`][FuzzyHits-class],
 #' and `value` is an object of a class specified in the S4 method signature or as outlined in 'Accessors'.
 #'
 #' @name FuzzyHits-methods
@@ -40,7 +40,7 @@ NULL
 #'
 #' This page documents the S4 generics and methods defined for objects inheriting of the [`IdVector`][IdVector-class] class.
 #' The `IdVector` class directly extends [`Vector`][`Vector-class`] and thus inherits of all methods defined for the parent class.
-#' In the usage below, `x` represents an object of class inheriting from [`IdVector`][IdVector-class],
+#' In the usage below, `object` and `x` represent an object of class inheriting from [`IdVector`][IdVector-class],
 #' and `value` is an object of a class specified in the S4 method signature or as outlined in 'Accessors'.
 #'
 #' @name IdVector-methods
@@ -58,7 +58,7 @@ NULL
 #'
 #' This page documents the S4 generics and methods defined for objects inheriting of the [`FuzzySets`][FuzzySets-class] class.
 #' The `FuzzySets` class directly extends [`BaseSets`][`BaseSets-class`] and thus inherits of all methods defined for the parent class.
-#' In the usage below, `x` represents an object of class inheriting from [`FuzzySets`][FuzzySets-class],
+#' In the usage below, `object` and `x` represent an object of class inheriting from [`FuzzySets`][FuzzySets-class],
 #' and `value` is an object of a class specified in the S4 method signature or as outlined in 'Accessors'.
 #'
 #' @name FuzzySets-methods

--- a/R/IdVector-class.R
+++ b/R/IdVector-class.R
@@ -193,7 +193,8 @@ setMethod("pcompare", c("IdVector", "ANY"), function(x, y)
 #' @rdname IdVector-methods
 #' @aliases as.vector.IdVector as.vector
 #'
-#' @param mode Ignored. The vector will be coerced to `character` mode, unless requested otherwise.
+#' @param mode Atomic type of the [`vector()`] returned.
+#' character string naming an atomic mode or "list" or "expression" or (except for vector) "any".
 #'
 #' @section Coercion:
 #' `as(x, "vector")` and `as.vector(x)` return an atomic vector of identifiers contained in `x`.

--- a/man/BaseSets-class.Rd
+++ b/man/BaseSets-class.Rd
@@ -10,11 +10,15 @@ BaseSets(relations = DataFrame(element = character(0), set =
   character(0)), elementData, setData)
 }
 \arguments{
-\item{relations}{DataFrame. Two columns provide mapping relationships between \code{"element"} and \code{"set"}.}
+\item{relations}{\code{\linkS4class{DataFrame}}.
+At least two columns that provide mapping relationships between \code{"element"} and \code{"set"}.
+Additional columns are taken as relation metadata.}
 
-\item{elementData}{DataFrame. Provide metadata for each unique element in \code{relations$element}.}
+\item{elementData}{\code{\link{IdVector}}.
+Metadata for each unique element in \code{relations$element} is provided as \code{mcols(elementData)}.}
 
-\item{setData}{DataFrame. Provide metadata for each unique element in \code{relations$set}.}
+\item{setData}{\code{\link{IdVector}}.
+Metadata for each unique set in \code{relations$set} is provided as \code{mcols(setData)}.}
 }
 \value{
 A \code{BaseSets} object.
@@ -25,11 +29,15 @@ The \code{BaseSets} class implements a container to describe distinct objects th
 \section{Slots}{
 
 \describe{
-\item{\code{relations}}{DataFrame. Two columns provide mapping relationships between \code{"element"} and \code{"set"}.}
+\item{\code{relations}}{\code{\linkS4class{Hits}}
+The \emph{left node} and \emph{right node} of each hit stores the index of the \code{element} and \code{set} in \code{elementData} and \code{setData}, respectively.
+Metadata for each relation is stored as \code{mcols(object@relations)}.}
 
-\item{\code{elementData}}{DataFrame. Provide metadata for each unique element in \code{relations$element}.}
+\item{\code{elementData}}{\code{\link{IdVector}}.
+Metadata for each unique element in \code{relations$element} is stored as \code{mcols(elementData)}.}
 
-\item{\code{setData}}{DataFrame. Provide metadata for each unique element in \code{relations$set}.}
+\item{\code{setData}}{\code{\link{IdVector}}.
+Metadata for each unique set in \code{relations$set} is stored as \code{mcols(setData)}.}
 }}
 
 \examples{

--- a/man/BaseSets-methods.Rd
+++ b/man/BaseSets-methods.Rd
@@ -130,7 +130,7 @@ The matrix will be coerced to \code{logical} type and relations indicating \code
 }
 \description{
 This page documents the S4 generics and methods defined for objects inheriting of the \code{\link[=BaseSets-class]{BaseSets}} class.
-In the usage below, \code{x} represents an object of class inheriting from \code{\link[=BaseSets-class]{BaseSets}},
+In the usage below, \code{object} and \code{x} represent an object of class inheriting from \code{\link[=BaseSets-class]{BaseSets}},
 and \code{value} is an object of a class specified in the S4 method signature or as outlined in 'Accessors'.
 }
 \section{Accessors}{

--- a/man/FuzzyHits-methods.Rd
+++ b/man/FuzzyHits-methods.Rd
@@ -26,7 +26,7 @@ membership(object) <- value
 \description{
 This page documents the S4 generics and methods defined for objects inheriting of the \code{\link[=FuzzyHits-class]{FuzzyHits}} class.
 The \code{FuzzyHits} class directly extends \code{\link[=Hits-class]{Hits}} and thus inherits of all methods defined for the parent class.
-In the usage below, \code{x} represents an object of class inheriting from \code{\link[=FuzzyHits-class]{FuzzyHits}},
+In the usage below, \code{object} represents an object of class inheriting from \code{\link[=FuzzyHits-class]{FuzzyHits}},
 and \code{value} is an object of a class specified in the S4 method signature or as outlined in 'Accessors'.
 }
 \section{Accessors}{

--- a/man/FuzzySets-class.Rd
+++ b/man/FuzzySets-class.Rd
@@ -10,7 +10,9 @@ FuzzySets(relations = DataFrame(element = character(0), set =
   character(0), membership = numeric(0)), ...)
 }
 \arguments{
-\item{relations}{DataFrame. At least 3 columns provide mapping relationships between \code{"element"} and \code{"set"} with \code{"membership"} function in the range \code{[0,1]}.}
+\item{relations}{\code{\linkS4class{DataFrame}}.
+At least 3 columns that provide mapping relationships between \code{"element"} and \code{"set"}, with \code{"membership"} function in the range \code{[0,1]}.
+Additional columns are taken as relation metadata.}
 
 \item{...}{Arguments passed to the \code{\link[=BaseSets]{BaseSets()}} constructor and other functions.}
 }
@@ -18,7 +20,7 @@ FuzzySets(relations = DataFrame(element = character(0), set =
 A \code{FuzzySets} object.
 }
 \description{
-The \code{FuzzySets} class extends the \code{\link{BaseSets}} class to implement a container that also describe different grades of membershipin the interval \code{[0,1]}.
+The \code{FuzzySets} class extends the \code{\link{BaseSets}} class to implement a container that also describe different grades of membership in the interval \code{[0,1]}.
 }
 \details{
 This class does not define any additional slot to the \code{BaseSets} class.

--- a/man/FuzzySets-methods.Rd
+++ b/man/FuzzySets-methods.Rd
@@ -38,7 +38,7 @@ The matrix will be coerced to \code{double} type and the value will be taken to 
 \description{
 This page documents the S4 generics and methods defined for objects inheriting of the \code{\link[=FuzzySets-class]{FuzzySets}} class.
 The \code{FuzzySets} class directly extends \code{\link[=BaseSets-class]{BaseSets}} and thus inherits of all methods defined for the parent class.
-In the usage below, \code{x} represents an object of class inheriting from \code{\link[=FuzzySets-class]{FuzzySets}},
+In the usage below, \code{object} and \code{x} represent an object of class inheriting from \code{\link[=FuzzySets-class]{FuzzySets}},
 and \code{value} is an object of a class specified in the S4 method signature or as outlined in 'Accessors'.
 }
 \section{Accessors}{

--- a/man/IdVector-class.Rd
+++ b/man/IdVector-class.Rd
@@ -25,7 +25,7 @@ Subclasses of \code{IdVector} may be defined to enable method dispatch according
 \section{Slots}{
 
 \describe{
-\item{\code{ids}}{character. Unique identifiers.}
+\item{\code{ids}}{character. Identifiers.}
 }}
 
 \examples{

--- a/man/IdVector-methods.Rd
+++ b/man/IdVector-methods.Rd
@@ -50,14 +50,15 @@ as.IdVector.default(ids, ...)
 
 \item{j, ..., drop}{Ignored.}
 
-\item{mode}{Ignored. The vector will be coerced to \code{character} mode, unless requested otherwise.}
+\item{mode}{Atomic type of the \code{\link[=vector]{vector()}} returned.
+character string naming an atomic mode or "list" or "expression" or (except for vector) "any".}
 
 \item{ids}{An atomic vector of identifiers.}
 }
 \description{
 This page documents the S4 generics and methods defined for objects inheriting of the \code{\link[=IdVector-class]{IdVector}} class.
 The \code{IdVector} class directly extends \code{\link[=Vector-class]{Vector}} and thus inherits of all methods defined for the parent class.
-In the usage below, \code{x} represents an object of class inheriting from \code{\link[=IdVector-class]{IdVector}},
+In the usage below, \code{object} and \code{x} represent an object of class inheriting from \code{\link[=IdVector-class]{IdVector}},
 and \code{value} is an object of a class specified in the S4 method signature or as outlined in 'Accessors'.
 }
 \section{Accessors}{

--- a/man/unisets-package.Rd
+++ b/man/unisets-package.Rd
@@ -16,6 +16,7 @@ Useful links:
 \itemize{
   \item \url{https://github.com/kevinrue/unisets}
   \item \url{http://kevinrue.github.io/unisets}
+  \item Report bugs at \url{https://github.com/kevinrue/unisets/issues}
 }
 
 }

--- a/vignettes/bioc-annotation.Rmd
+++ b/vignettes/bioc-annotation.Rmd
@@ -91,7 +91,7 @@ format(length(base_sets), big.mark=",")
 
 We can also examine the count of relations associated with each evidence code in each Gene Ontology namespace.
 
-```{r, fig.height=6}
+```{r, fig.height=7}
 ggplot(as.data.frame(base_sets)) +
     geom_bar(aes(Evidence)) + facet_wrap(~Ontology, ncol = 1) + coord_flip() +
     # scale_y_continuous(labels = function(x){ format(as.integer(x), big.mark = ",") }) +


### PR DESCRIPTION
document "object" and "x" as some signatures use either; "relations" slot actually uses `Hits` class; stretch figure in vignette.